### PR TITLE
Create cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/app', '.']
+
+  - name: gcr.io/cloud-builders/docker
+    args: ['push', 'gcr.io/$PROJECT_ID/app']
+
+images:
+  - gcr.io/$PROJECT_ID/app


### PR DESCRIPTION
This PR adds a cloudbuild.yaml file required for Google Cloud Build triggers.

The configuration:
- Builds a Docker image using the Dockerfile in the repository
- Tags the image as gcr.io/$PROJECT_ID/app
- Pushes the image to Google Container Registry
- Ensures Cloud Build can successfully run the trigger without the
  "We could not find a valid build file" error

This enables automated CI/CD for the main branch.
