### PR TITLE
Add Slack alerting functionality

### DIFF
--- a/backend/🚨 backend/alerting.js
+++ b/backend/🚨 backend/alerting.js
@@ -1,0 +1,9 @@
+const axios = require('axios')
+
+function sendSlackAlert(message) {
+  const url = process.env.SLACK_WEBHOOK_URL
+  if (!url) return
+  axios.post(url, { text: `🚨 [UnionLedger] ALERT: ${message}` })
+}
+
+module.exports = { sendSlackAlert }


### PR DESCRIPTION
This pull request adds a new utility for sending alerts to Slack from the backend. The main change is the implementation of a `sendSlackAlert` function that posts alert messages to a Slack webhook using Axios.

Backend alerting:

* Added `sendSlackAlert` function in `backend/alerting.js` to send alert messages to a Slack channel via a webhook, utilizing the `axios` library.