### PR TITLE
Add manual test script for trading API

### DIFF
--- a/scripts/manual-test.sh
+++ b/scripts/manual-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+curl -X POST http://localhost:8080/api/trading/start
+curl http://localhost:8080/api/trading/status
+curl http://localhost:8080/api/trading/history


### PR DESCRIPTION
This pull request adds a new shell script to facilitate manual testing of the trading API. The script sends requests to start trading, check trading status, and retrieve trading history.

- Manual testing automation:
  * Added a new script `scripts/manual-test.sh` that sends HTTP requests to the trading API endpoints for starting trading, checking status, and retrieving history.