### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xpertforextradeinc/unionledger/security/code-scanning/1](https://github.com/xpertforextradeinc/unionledger/security/code-scanning/1)

To fix the problem, explicitly define a `permissions:` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. In this workflow, the steps only need to check out the code, install Node.js dependencies, run a server, and make HTTP calls; they do not need to write to the repository or modify other GitHub resources. Therefore, `contents: read` at the workflow (root) level is sufficient and will apply to all jobs.

The best fix with no change in functionality is to add a root‑level `permissions:` section (between the `on:` block and the `jobs:` block) in `.github/workflows/main.yml`:

- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `on:` configuration. This restricts the `GITHUB_TOKEN` to read repository contents, which is enough for `actions/checkout@v3` and does not affect the rest of the steps, as they only interact with the local environment and a local HTTP server.

No new methods, imports, or other definitions are required; this is purely a YAML configuration change within the shown file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
