### PR TITLE
Add Mayhem for API workflow

### DIFF
--- a/.github/workflows/mayhem-for-api.yml
+++ b/.github/workflows/mayhem-for-api.yml
@@ -1,0 +1,64 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# This workflow starts your API and fuzzes it with ForAllSecure Mayhem for API
+# to find reliability, performance and security issues before they reach
+# production.
+#
+# To use this workflow, you will need to:
+#
+# 1. Create a Mayhem account at https://app.mayhem.security
+#
+# 2. Create an API token at https://app.mayhem.security/-/settings/user/api-tokens
+#
+# 3. Add the API token as a secret in GitHub called "MAYHEM_TOKEN"
+#
+# 4. Update the "Start your API" step to run your API in the background before
+#    starting the Mayhem for API scan, and update the `api-url` & `api-spec`
+#    field.
+#
+# If you have any questions, please contact us at mayhem4api@forallsecure.com
+
+name: "Mayhem for API"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+
+jobs:
+  mayhem-for-api:
+    name: Mayhem for API
+    # Mayhem for API runs on linux, mac and windows
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Run your API in the background. Ideally, the API would run in debug
+      # mode & send stacktraces back on "500 Internal Server Error" responses
+      # (don't do this in production though!)
+      - name: Start your API
+        run: ./run_your_api.sh & # <- ✏️ update this
+
+      - name: Mayhem for API
+        uses: ForAllSecure/mapi-action@v1
+        continue-on-error: true
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          api-url: http://localhost:8080 # <- ✏️ update this
+          api-spec: http://localhost:8080/openapi.json # <- ✏️ update this
+          duration: 60
+          sarif-report: mapi.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: mapi.sarif


### PR DESCRIPTION
This workflow sets up Mayhem for API to fuzz the API for reliability, performance, and security issues. It includes steps for starting the API and running the Mayhem scan.